### PR TITLE
Run AfterProceed even if exception thrown

### DIFF
--- a/src/Lightwind.AsyncInterceptor/AsyncInterceptorBase.cs
+++ b/src/Lightwind.AsyncInterceptor/AsyncInterceptorBase.cs
@@ -21,14 +21,21 @@ namespace Lightwind.AsyncInterceptor
         public void Intercept(IInvocation invocation)
         {
             BeforeProceed(invocation);
-            invocation.Proceed();
-            if (IsAsyncMethod(invocation.MethodInvocationTarget))
+            try
             {
-                invocation.ReturnValue = InterceptAsync((dynamic)invocation.ReturnValue, invocation);
+                invocation.Proceed();
             }
-            else
+            finally
             {
-                AfterProceedSync(invocation);
+                invocation.Proceed();
+                if (IsAsyncMethod(invocation.MethodInvocationTarget))
+                {
+                    invocation.ReturnValue = InterceptAsync((dynamic)invocation.ReturnValue, invocation);
+                }
+                else
+                {
+                    AfterProceedSync(invocation);
+                }
             }
         }
 


### PR DESCRIPTION
To be sure that the AfterProceed will run with an unhandled exception when invocation proceeded.